### PR TITLE
Fix issue causing `System error`

### DIFF
--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -5,6 +5,7 @@ use std::ffi::CStr;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use errors::Result;
 
+#[derive(Debug)]
 pub enum AddressFamily {
     Ipv4,
     Ipv6
@@ -12,6 +13,7 @@ pub enum AddressFamily {
 
 /// A list of addresses that are of the same address family (either all IPv4 or
 /// all IPv6).
+#[derive(Debug)]
 pub enum HostAddressList {
     V4(Vec<Ipv4Addr>),
     V6(Vec<Ipv6Addr>),
@@ -19,6 +21,7 @@ pub enum HostAddressList {
 
 /// Information about a host, the type of record returned by `gethostbyname`
 /// and friends.
+#[derive(Debug)]
 pub struct HostEntry<'a> {
     pub name: Cow<'a, CStr>,
     pub aliases: Vec<Cow<'a, CStr>>,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,5 @@
 use alloc::BumpAllocator;
-use errors::{Error, Result, NETDB_INTERNAL};
+use errors::{Error, Result};
 pub use errors::NssStatus;
 use interfaces::{AddressFamily, HostEntry, HostAddressList, NameService};
 use libc::{AF_INET, AF_INET6, in_addr_t, in6_addr };
@@ -109,11 +109,7 @@ pub fn write_host_lookup_result(
     match lookup_result {
         Err(err) => unsafe { err.report_with_host(errnop, h_errnop) },
 
-        Ok(None) => unsafe {
-            *errnop = 0;
-            *h_errnop = NETDB_INTERNAL;
-            NssStatus::NotFound
-        }
+        Ok(None) => NssStatus::NotFound,
 
         Ok(Some(host)) => unsafe {
             match host.write_to(resultp, buffer, buflen) {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -140,6 +140,7 @@ pub unsafe fn call_gethostbyname_r<T: NameService>(
 #[macro_export]
 macro_rules! nssglue_gethostbyname_r {
     ($name:ident, $t:ty) => {
+        #[no_mangle]
         pub unsafe extern "C" fn $name(
             name: *const $crate::macros::c_char,
             result: *mut $crate::macros::hostent,
@@ -204,6 +205,7 @@ pub unsafe fn call_gethostbyname2_r<T: NameService>(
 #[macro_export]
 macro_rules! nssglue_gethostbyname2_r {
     ($name:ident, $t:ty) => {
+        #[no_mangle]
         pub unsafe extern "C" fn $name(
             name: *const $crate::macros::c_char,
             af: $crate::macros::c_int,
@@ -261,6 +263,7 @@ pub unsafe fn call_gethostbyaddr_r<T: NameService>(
 #[macro_export]
 macro_rules! nssglue_gethostbyaddr_r {
     ($name:ident, $t:ty) => {
+        #[no_mangle]
         pub unsafe extern "C" fn $name(
             addr: *const $crate::macros::c_void,
             len: $crate::macros::c_int,


### PR DESCRIPTION
When implementing the example and placing the resolver's name in `/etc/nsswitch.conf`, all non-matching domains fail to pass through.

A simple `ping google.com` would result in `System error` message.

I traced the code to this section, removed it and things started working as exected.

Also, the functions the implement the callbacks required `#[no_mangle]`. Prior to this, the custom module was not being invoked at all.

I also added `#[derive(Debug)]` to a few of the structs to allow for easier debugging.

There still remains an issue with a segfault for domains that match:

```
λ ping local.test
fish: “ping local.test” terminated by signal SIGSEGV (Address boundary error)
```

I've traced the issue to the following lines:
- https://github.com/jorendorff/nsswitch_service/blob/master/src/macros.rs#L82
- https://github.com/jorendorff/nsswitch_service/blob/master/src/alloc.rs#L91

Unfortunately, my lack of C has stopped me from getting any further.